### PR TITLE
Offline areas download target correctly tracks viewport during map interaction

### DIFF
--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/AppContent.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/AppContent.kt
@@ -228,7 +228,16 @@ fun AppContent(
                             }
                         }
                         val viewModel: OfflineAreasViewModel = hiltViewModel()
-                        cameraState.projection?.queryVisibleRegion()?.let { visibleRegion ->
+                        
+                        // Track the current viewport reactively
+                        var currentViewport by remember { mutableStateOf(cameraState.projection?.queryVisibleRegion()) }
+                        
+                        // Update viewport when camera state changes
+                        LaunchedEffect(cameraState.position) {
+                            currentViewport = cameraState.projection?.queryVisibleRegion()
+                        }
+                        
+                        currentViewport?.let { visibleRegion ->
                             OfflineAreasScreen(
                                 currentViewport = visibleRegion,
                                 viewModel = viewModel,

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/OfflineAreasScreen.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/OfflineAreasScreen.kt
@@ -347,7 +347,7 @@ fun DownloadAreaDialog(
     val viewModel: OfflineAreasViewModel = hiltViewModel()
 
     // Calculate default bounding box from current viewport
-    val (defaultNorth, defaultSouth, defaultEast, defaultWest) = calculateBoundingBoxFromViewport(
+    val (north, south, east, west) = calculateBoundingBoxFromViewport(
         currentViewport
     )
 
@@ -362,10 +362,6 @@ fun DownloadAreaDialog(
     // Create a FocusRequester to request focus on the text field
     val focusRequester = remember { FocusRequester() }
 
-    val north = defaultNorth.toDouble()
-    val south = defaultSouth.toDouble()
-    val east = defaultEast.toDouble()
-    val west = defaultWest.toDouble()
     val minZoom = 7
     val maxZoom = 14
 
@@ -375,7 +371,7 @@ fun DownloadAreaDialog(
     val estimatedTileCount by remember(north, south, east, west) {
         mutableIntStateOf(
             if (north >= south && east >= west) {
-                viewModel.estimateTileCount(north, south, east, west, minZoom, maxZoom)
+                viewModel.estimateTileCount(north.toDouble(), south, east, west, minZoom, maxZoom)
             } else {
                 0
             }
@@ -470,22 +466,17 @@ fun formatFileSize(bytes: Long): String {
 fun calculateBoundingBoxFromViewport(
     viewport: VisibleRegion
 ): BoundingBox {
-    val north = viewport.farLeft.latitude
-    val south = viewport.nearRight.latitude
-    val east = viewport.nearRight.longitude
-    val west = viewport.farLeft.longitude
-
     return BoundingBox(
-        north.toString(),
-        south.toString(),
-        east.toString(),
-        west.toString()
+        north = viewport.farLeft.latitude,
+        south = viewport.nearRight.latitude,
+        east = viewport.nearRight.longitude,
+        west = viewport.farLeft.longitude,
     )
 }
 
 data class BoundingBox(
-    val north: String,
-    val south: String,
-    val east: String,
-    val west: String
+    val north: Double,
+    val south: Double,
+    val east: Double,
+    val west: Double
 )


### PR DESCRIPTION
This fixes an annoying bug where you'd open the offline areas screen and pan around or zoom and by the time you press the download button you're far away from the original viewport, but the app downloads the original viewport anyway.