### PR TITLE
Fix OSM/MapLibre attribution

### DIFF
--- a/cardinal-android/app/src/main/assets/style_dark.json
+++ b/cardinal-android/app/src/main/assets/style_dark.json
@@ -12,7 +12,8 @@
       "tiles": [
         "http://127.0.0.1:{port}/openmaptiles/{z}/{x}/{y}.pbf"
       ],
-      "maxzoom": 14
+      "maxzoom": 14,
+      "attribution": "© OpenStreetMap contributors"
     },
     "landcover": {
       "type": "vector",
@@ -3710,8 +3711,16 @@
       "minzoom": 7,
       "filter": [
         "all",
-        ["<=", "ref_length", 6],
-        ["!=", "subclass", "junction"]
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "!=",
+          "subclass",
+          "junction"
+        ]
       ],
       "layout": {
         "icon-image": "default_{ref_length}",

--- a/cardinal-android/app/src/main/assets/style_light.json
+++ b/cardinal-android/app/src/main/assets/style_light.json
@@ -12,7 +12,8 @@
       "tiles": [
         "http://127.0.0.1:{port}/openmaptiles/{z}/{x}/{y}.pbf"
       ],
-      "maxzoom": 14
+      "maxzoom": 14,
+      "attribution": "© OpenStreetMap contributors"
     },
     "landcover": {
       "type": "vector",
@@ -3710,8 +3711,16 @@
       "minzoom": 7,
       "filter": [
         "all",
-        ["<=", "ref_length", 6],
-        ["!=", "subclass", "junction"]
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "!=",
+          "subclass",
+          "junction"
+        ]
       ],
       "layout": {
         "icon-image": "default_{ref_length}",

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/MapView.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/MapView.kt
@@ -146,7 +146,12 @@ fun MapView(
                 baseStyle = BaseStyle.Uri("http://127.0.0.1:$port/style_$styleVariant.json"),
                 styleState = styleState,
                 options = MapOptions(
-                    ornamentOptions = OrnamentOptions.AllDisabled, renderOptions = RenderOptions()
+                    ornamentOptions = OrnamentOptions.AllDisabled.copy(
+                        padding = fabInsets,
+                        isAttributionEnabled = true,
+                        attributionAlignment = Alignment.BottomStart
+                    ),
+                    renderOptions = RenderOptions()
                 ),
                 onMapClick = { position, dpOffset ->
                     mapViewModel.handleMapTap(

--- a/cardinal-android/app/src/main/res/values/strings.xml
+++ b/cardinal-android/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="download_new_area">Download current viewport</string>
     <string name="downloading">Downloading</string>
     <string name="downloading_area">Downloading %1$s</string>
-    <string name="preparing_download">Preparing download...</string>
+    <string name="preparing_download">Preparing download…</string>
     <string name="download_progress">%1$d / %2$d tiles</string>
     <string name="saved_offline_areas">Saved Offline Areas</string>
     <string name="no_offline_areas">No offline areas downloaded yet</string>
@@ -160,7 +160,7 @@
     <string name="accessibility_settings_summary">Adjust accessibility settings for better usability</string>
     <string name="advanced_settings_summary">Configure advanced settings for the app</string>
     <string name="app_name_long">Cardinal Maps</string>
-    <string name="call_to_action">If you\'re enjoying the app please consider contributing bug reports, feature requests, storage/compute resources, or sponsoring the project.</string>
+    <string name="call_to_action">If you\'re enjoying the app please consider contributing bug reports, feature requests, storage/compute resources, or sponsoring the project. Map data from OpenStreetMap.</string>
     <string name="open_cardinal_maps_github_repository_in_browser">Open cardinal maps GitHub repository in browser</string>
     <string name="no_routing_profiles_configured_yet">No routing profiles configured yet.</string>
     <string name="unnamed_location">Unnamed Location</string>


### PR DESCRIPTION
For some reason the attribution ornament isn't showing the attributions set in the tile sources, so I added a second attribution to the settings screen just to be sure. Will report this bug upstream when I get a chance.