### PR TITLE
Pass explicit GTFS IDs around to ensure correct departures shown

### DIFF
--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/data/Place.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/data/Place.kt
@@ -25,5 +25,6 @@ data class Place(
     val address: Address? = null,
     val isMyLocation: Boolean = false,
     val isTransitStop: Boolean = false,
+    val transitStopId: String? = null,
 )
 

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/AppDatabase.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/AppDatabase.kt
@@ -27,7 +27,7 @@ import earth.maps.cardinal.data.DownloadStatusConverter
 
 @Database(
     entities = [OfflineArea::class, RoutingProfile::class, DownloadedTile::class, SavedList::class, SavedPlace::class, ListItem::class],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 @TypeConverters(TileTypeConverter::class, DownloadStatusConverter::class, ItemTypeConverter::class)
@@ -180,6 +180,14 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE saved_places ADD COLUMN transitStopId TEXT"
+                )
+            }
+        }
+
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
@@ -193,6 +201,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_6_7,
                     MIGRATION_7_8,
                     MIGRATION_8_9,
+                    MIGRATION_9_10,
                 ).build()
                 INSTANCE = instance
                 instance

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/SavedPlace.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/SavedPlace.kt
@@ -42,6 +42,7 @@ data class SavedPlace(
     val country: String? = null,
     val countryCode: String? = null,
     val isTransitStop: Boolean = false,
+    val transitStopId: String? = null,
     val createdAt: Long,
     val updatedAt: Long
 ) {
@@ -68,8 +69,9 @@ data class SavedPlace(
                 country = place.address?.country,
                 countryCode = place.address?.countryCode,
                 isTransitStop = place.isTransitStop,
+                transitStopId = place.transitStopId,
                 createdAt = timestamp,
-                updatedAt = timestamp
+                updatedAt = timestamp,
             )
         }
     }

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/SavedPlaceRepository.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/data/room/SavedPlaceRepository.kt
@@ -47,14 +47,11 @@ class SavedPlaceRepository @Inject constructor(
      * Saves a place.
      */
     suspend fun savePlace(
-        place: Place,
-        customName: String? = null,
-        customDescription: String? = null
+        place: Place, customName: String? = null, customDescription: String? = null
     ): Result<String> = withContext(Dispatchers.IO) {
         try {
             val savedPlace = SavedPlace.fromPlace(place).copy(
-                customName = customName,
-                customDescription = customDescription
+                customName = customName, customDescription = customDescription
             )
 
             placeDao.insertPlace(savedPlace)
@@ -68,13 +65,12 @@ class SavedPlaceRepository @Inject constructor(
      * Updates a saved place.
      */
     suspend fun updatePlace(
-        placeId: String,
-        customName: String? = null,
-        customDescription: String? = null
+        placeId: String, customName: String? = null, customDescription: String? = null
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            val existingPlace = placeDao.getPlace(placeId)
-                ?: return@withContext Result.failure(IllegalArgumentException("Place not found"))
+            val existingPlace = placeDao.getPlace(placeId) ?: return@withContext Result.failure(
+                IllegalArgumentException("Place not found")
+            )
 
             val updatedPlace = existingPlace.copy(
                 customName = customName ?: existingPlace.customName,
@@ -94,8 +90,9 @@ class SavedPlaceRepository @Inject constructor(
      */
     suspend fun deletePlace(placeId: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            val place = placeDao.getPlace(placeId)
-                ?: return@withContext Result.failure(IllegalArgumentException("Place not found"))
+            val place = placeDao.getPlace(placeId) ?: return@withContext Result.failure(
+                IllegalArgumentException("Place not found")
+            )
 
             placeDao.deletePlace(place)
             Result.success(Unit)
@@ -133,13 +130,9 @@ class SavedPlaceRepository @Inject constructor(
             description = savedPlace.type,
             icon = savedPlace.icon,
             latLng = earth.maps.cardinal.data.LatLng(
-                latitude = savedPlace.latitude,
-                longitude = savedPlace.longitude
+                latitude = savedPlace.latitude, longitude = savedPlace.longitude
             ),
-            address = if (savedPlace.houseNumber != null || savedPlace.road != null || savedPlace.city != null ||
-                savedPlace.state != null || savedPlace.postcode != null || savedPlace.country != null ||
-                savedPlace.countryCode != null
-            ) {
+            address = if (savedPlace.houseNumber != null || savedPlace.road != null || savedPlace.city != null || savedPlace.state != null || savedPlace.postcode != null || savedPlace.country != null || savedPlace.countryCode != null) {
                 earth.maps.cardinal.data.Address(
                     houseNumber = savedPlace.houseNumber,
                     road = savedPlace.road,
@@ -152,7 +145,8 @@ class SavedPlaceRepository @Inject constructor(
             } else {
                 null
             },
-            isTransitStop = savedPlace.isTransitStop
+            isTransitStop = savedPlace.isTransitStop,
+            transitStopId = savedPlace.transitStopId,
         )
     }
 }

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/TransitScreen.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/TransitScreen.kt
@@ -147,11 +147,9 @@ fun TransitScreenContent(
                 modifier = Modifier.padding(vertical = 8.dp)
             )
         } else {
-            val maxDeparturesPerHeadsign = 3
             // List of departures grouped by route and headsign
             TransitScreenRouteDepartures(
                 stopTimes = viewModel.departures.value,
-                maxDepartures = maxDeparturesPerHeadsign,
                 onRouteClicked = onRouteClicked,
             )
         }
@@ -162,7 +160,7 @@ fun TransitScreenContent(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun TransitScreenRouteDepartures(
-    stopTimes: List<StopTime>, maxDepartures: Int, onRouteClicked: (Place) -> Unit
+    stopTimes: List<StopTime>, onRouteClicked: (Place) -> Unit
 ) {
     // Group departures by route name
     val departuresByRoute = stopTimes.groupBy { it.routeShortName }
@@ -182,7 +180,7 @@ fun TransitScreenRouteDepartures(
 
         // Group departures by headsign within each route
         val departuresByHeadsign = departures.groupBy { it.headsign }.map { (key, value) ->
-            (key to value.take(maxDepartures))
+            (key to value.take(1))
         }.toMap()
         val headsigns = departuresByHeadsign.keys.toList().sorted()
 
@@ -194,7 +192,8 @@ fun TransitScreenRouteDepartures(
                         name = departure.place.name,
                         description = transitStopString,
                         latLng = LatLng(departure.place.lat, departure.place.lon),
-                        isTransitStop = true
+                        isTransitStop = true,
+                        transitStopId = departure.place.stopId,
                     )
                 }
             }.toMap()

--- a/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/TransitStopScreen.kt
+++ b/cardinal-android/app/src/main/java/earth/maps/cardinal/ui/TransitStopScreen.kt
@@ -161,7 +161,7 @@ fun TransitStopInformation(viewModel: TransitStopCardViewModel, onRouteClicked: 
                 modifier = Modifier.padding(vertical = 8.dp)
             )
         } else {
-            val maxDeparturesPerHeadsign = 3
+            val maxDeparturesPerHeadsign = 5
             // List of departures grouped by route and headsign
             RouteDepartures(
                 stopTimes = viewModel.departures.value,


### PR DESCRIPTION
This fixes a serious bug in v0.10.0 where tapping a departure in the transit screen would take you to the completely wrong stop, and you'd only catch it if you saw the headsign in the stop departures card.